### PR TITLE
fix segment fault when connect command is executed with less than 2 args.

### DIFF
--- a/src/client/command.cpp
+++ b/src/client/command.cpp
@@ -207,6 +207,11 @@ int ICommand::sendOrder( ossSocket & sock, int opCode )
 int ConnectCommand::execute( ossSocket & sock, std::vector<std::string> & argVec )
 {
    int ret = EDB_OK;
+   if(argVec.size() < 2)
+   {
+      printf("too little argument for fuction: ConnectCommand::execute()\n");
+      goto error;
+   }
    _address = argVec[0];
    _port = atoi(argVec[1].c_str());
    sock.close();


### PR DESCRIPTION
fix segment fault when connect command is executed with less than 2 args.
By Akim, Student No. 124
